### PR TITLE
Fire and forget

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The response code can be used to distinguish failed and successful samples
 (similar to JMeter's [HTTP Request](https://jmeter.apache.org/usermanual/component_reference.html#HTTP_Request)
 marking 4xx and 5xx responses as failures).
 - *Timeout (ms)*: A response timeout in milliseconds can be defined individually for each sampler.
-  A negative value can be used to send requests without expecting any response message 
+  The value 0 can be used to send requests without expecting any response message 
   (["fire and forget"](https://www.enterpriseintegrationpatterns.com/patterns/conversation/FireAndForget.html)).
 - *Response Code Field* (usually 39): Field number that is used to determine a sample success or failure.
 - *Success Response Code* (usually 00): Expected value for successful responses.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ The response code can be used to distinguish failed and successful samples
 (similar to JMeter's [HTTP Request](https://jmeter.apache.org/usermanual/component_reference.html#HTTP_Request)
 marking 4xx and 5xx responses as failures).
 - *Timeout (ms)*: A response timeout in milliseconds can be defined individually for each sampler.
-  The value 0 turns off the timeout, and should be used with care.
+  A negative value can be used to send requests without expecting any response message 
+  (["fire and forget"](https://www.enterpriseintegrationpatterns.com/patterns/conversation/FireAndForget.html)).
 - *Response Code Field* (usually 39): Field number that is used to determine a sample success or failure.
 - *Success Response Code* (usually 00): Expected value for successful responses.
 

--- a/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
@@ -161,7 +161,12 @@ public class ISO8583Sampler extends AbstractSampler
 
         // Response validation...
         if (response == null) {
-            result.setResponseMessage("Timeout");
+            if (getTimeout() >= 0) {
+                result.setResponseMessage("Timeout");
+            } else { // fire-and-forget
+                result.setResponseMessage("No response");
+                result.setSuccessful(true);
+            }
             return result;
         }
         result.setSuccessful(true); // at least we received a response, so start off as success
@@ -196,7 +201,12 @@ public class ISO8583Sampler extends AbstractSampler
 
     protected ISOMsg sendRequest(ISOMsg request) throws ISOException, NameRegistrar.NotFoundException {
         MUX mux = QMUX.getMUX(config.getMuxName());
-        return mux.request(request, getTimeout());
+        if (getTimeout() >= 0) {
+            return mux.request(request, getTimeout());
+        } else {
+            mux.request(request, 0, (response, handback) -> {}, null); // fire-and-forget
+            return null;
+        }
     }
 
     protected ISOMsg buildRequest() {

--- a/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
@@ -161,11 +161,11 @@ public class ISO8583Sampler extends AbstractSampler
 
         // Response validation...
         if (response == null) {
-            if (getTimeout() >= 0) {
-                result.setResponseMessage("Timeout");
-            } else { // fire-and-forget
+            if (getTimeout() == 0) { // fire-and-forget
                 result.setResponseMessage("No response");
                 result.setSuccessful(true);
+            } else {
+                result.setResponseMessage("Timeout");
             }
             return result;
         }
@@ -201,12 +201,7 @@ public class ISO8583Sampler extends AbstractSampler
 
     protected ISOMsg sendRequest(ISOMsg request) throws ISOException, NameRegistrar.NotFoundException {
         MUX mux = QMUX.getMUX(config.getMuxName());
-        if (getTimeout() >= 0) {
-            return mux.request(request, getTimeout());
-        } else {
-            mux.request(request, 0, (response, handback) -> {}, null); // fire-and-forget
-            return null;
-        }
+        return mux.request(request, getTimeout());
     }
 
     protected ISOMsg buildRequest() {

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583CryptoTest.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583CryptoTest.java
@@ -22,8 +22,7 @@ public class ISO8583CryptoTest extends ISO8583TestBase {
 
     @Before
     public void setup() {
-        configureSampler(sampler, getDefaultTestConfig(),
-            asMessageFields(getDefaultTestMessage()).toArray(new MessageField[0]));
+        configureSampler(sampler, getDefaultTestConfig(), asMessageFields(getDefaultTestMessage()));
     }
 
     @Test

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
@@ -39,4 +39,34 @@ public class ISO8583SamplerIntegrationTest extends ISO8583TestBase {
         assertEquals("1122334455667788", response.getString("48.1"));
     }
 
+    @Test
+    public void shouldAllowFireAndForget() {
+        instance.addTestElement(config);
+        instance.addTestElement(getDefaultMessageComponent());
+        instance.setFields(asMessageFields(getDefaultTestMessage()));
+        instance.setTimeout(-1); // indicates fire-and-forget
+        SampleResult res = instance.sample(new Entry());
+        assertNotNull(res);
+        assertTrue(res.isSuccessful());
+        assertTrue(res.getResponseDataAsString().isEmpty());
+        assertEquals(0, res.getBytesAsLong());
+        assertEquals("No response", res.getResponseMessage());
+        assertNull(instance.getResponse());
+    }
+
+    @Test
+    public void shouldFailOnTimeout() {
+        instance.addTestElement(config);
+        instance.addTestElement(getDefaultMessageComponent());
+        instance.setFields(asMessageFields(getDefaultTestMessage()));
+        instance.addField("35", ""); // simulate delay
+        instance.setTimeout(500);
+        SampleResult res = instance.sample(new Entry());
+        assertNotNull(res);
+        assertFalse(res.isSuccessful());
+        assertTrue(res.getResponseDataAsString().isEmpty());
+        assertEquals(0, res.getBytesAsLong());
+        assertEquals("Timeout", res.getResponseMessage());
+        assertNull(instance.getResponse());
+    }
 }

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
@@ -43,9 +43,9 @@ public class ISO8583SamplerIntegrationTest extends ISO8583TestBase {
         assertEquals("1122334455667788", response.getString("48.1"));
     }
 
-//    @Test
+    @Test
     public void shouldAllowFireAndForget() {
-        instance.setTimeout(-1); // indicates fire-and-forget
+        instance.setTimeout(0); // indicates fire-and-forget
         SampleResult res = instance.sample(new Entry());
         assertNotNull(res);
         assertTrue(res.isSuccessful());

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583SamplerIntegrationTest.java
@@ -15,7 +15,7 @@ public class ISO8583SamplerIntegrationTest extends ISO8583TestBase {
 
     @BeforeClass
     public static void setupClass() {
-        config.testStarted(); // starts up Q2
+        config.testStarted(); // shares the Q2 instance with Q2ServerResource
     }
 
     @AfterClass
@@ -26,17 +26,14 @@ public class ISO8583SamplerIntegrationTest extends ISO8583TestBase {
     @Before
     public void setup() {
         instance = new ISO8583Sampler();
-        instance.addTestElement(config);
-        instance.addTestElement(getDefaultMessageComponent());
-        instance.setFields(asMessageFields(getDefaultTestMessage()));
+        configureSampler(instance, config, asMessageFields(getDefaultTestMessage()));
     }
 
     @Test
     public void shouldReceiveResponse() {
-        ISOMsg msg = instance.getRequest();
-        instance.setFields(asMessageFields(msg));
         instance.addField("48.1", "1122334455667788", "9f26");
         instance.setTimeout(5000);
+        ISOMsg msg = instance.getRequest();
         SampleResult res = instance.sample(new Entry());
         assertNotNull(res);
         assertFalse(res.getResponseDataAsString().isEmpty());
@@ -46,7 +43,7 @@ public class ISO8583SamplerIntegrationTest extends ISO8583TestBase {
         assertEquals("1122334455667788", response.getString("48.1"));
     }
 
-    @Test
+//    @Test
     public void shouldAllowFireAndForget() {
         instance.setTimeout(-1); // indicates fire-and-forget
         SampleResult res = instance.sample(new Entry());

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583TestBase.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583TestBase.java
@@ -2,10 +2,7 @@ package nz.co.breakpoint.jmeter.iso8583;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Random;
+import java.util.*;
 
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
@@ -66,7 +63,7 @@ public class ISO8583TestBase {
 
     public static ISO8583Component getDefaultMessageComponent() {
         ISO8583Component component = new ISO8583Component();
-        component.addField(new MessageField("11", String.format("%06d", new Random().nextInt(1000000))));
+        component.addField(new MessageField("11", "STAN"));
         return component;
     }
 
@@ -88,14 +85,18 @@ public class ISO8583TestBase {
 
     public ISOMsg getDefaultTestMessage() {
         ISOMsg msg = new ISOMsg("0800");
-        msg.set(11, "012345");
-        msg.set(41, "543210");
+        msg.set(11, String.format("%06d", System.currentTimeMillis() % 1000000));
+        msg.set(41, "JMETER");
         return msg;
     }
 
     public void configureSampler(ISO8583Sampler sampler, ISO8583Config config, MessageField... fields) {
+        configureSampler(sampler, config, asMessageFields(fields));
+    }
+
+    public void configureSampler(ISO8583Sampler sampler, ISO8583Config config, Collection<MessageField> fields) {
         ctx.context.setCurrentSampler(sampler);
-        sampler.setFields(asMessageFields(fields));
+        sampler.setFields(fields);
         sampler.addTestElement(config);
     }
 }

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583TestBase.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/ISO8583TestBase.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Random;
 
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
@@ -65,7 +66,7 @@ public class ISO8583TestBase {
 
     public static ISO8583Component getDefaultMessageComponent() {
         ISO8583Component component = new ISO8583Component();
-        component.addField(new MessageField("11", "STAN"));
+        component.addField(new MessageField("11", String.format("%06d", new Random().nextInt(1000000))));
         return component;
     }
 

--- a/src/test/java/nz/co/breakpoint/jmeter/iso8583/MessagePrinterTest.java
+++ b/src/test/java/nz/co/breakpoint/jmeter/iso8583/MessagePrinterTest.java
@@ -15,8 +15,8 @@ public class MessagePrinterTest extends ISO8583TestBase {
         String dump = MessagePrinter.asString(msg, true);
         assertTrue(dump.startsWith("<isomsg>"));
         assertTrue(dump.contains("<field id=\"0\" value=\"0800\"/>"));
-        assertTrue(dump.contains("<field id=\"11\" value=\"012345\"/>"));
-        assertTrue(dump.contains("<field id=\"41\" value=\"543210\"/>"));
+        assertTrue(dump.contains("<field id=\"11\" value=\""+msg.getString(11)+"\"/>"));
+        assertTrue(dump.contains("<field id=\"41\" value=\""+msg.getString(41)+"\"/>"));
         assertFalse(dump.contains("<!--")); // no packager, no hexdump
     }
 


### PR DESCRIPTION
The sampler should support sending of "fire-and-forget" messages, i.e. without expecting a response message, and without failing the sample as a timeout.
A response timeout value of 0 can be used to indicate the sampler is not supposed to wait for a response.