### PR TITLE
Don't touch request after sending to avoid concurrency bug

### DIFF
--- a/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
+++ b/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java
@@ -149,6 +149,18 @@ public class ISO8583Sampler extends AbstractSampler
 
         ISOMsg request = getRequest();
 
+        // Request details...
+        result.setRequestHeaders("Host: "+config.getHost()+"\nPort: "+config.getPort());
+        result.setSamplerData(MessagePrinter.asString(request, true));
+        try {
+            byte[] bytes = request.pack(), header = request.getHeader(), trailer = request.getTrailer();
+            log.debug("Packed request '{}'", ISOUtil.byte2hex(bytes));
+            result.setSentBytes((long) bytes.length +
+                    (header != null ? header.length : 0) + (trailer != null ? trailer.length : 0));
+        } catch (ISOException e) {
+            log.error("Packager error on request '{}'. Check config! {}", getName(), e.toString());
+        }
+
         // Send the request...
         log.debug("sampleStart");
         result.sampleStart();
@@ -161,18 +173,6 @@ public class ISO8583Sampler extends AbstractSampler
         } finally {
             log.debug("sampleEnd");
             result.sampleEnd();
-        }
-
-        // Request details...
-        result.setRequestHeaders("Host: "+config.getHost()+"\nPort: "+config.getPort());
-        result.setSamplerData(MessagePrinter.asString(request,true));
-        try {
-            byte[] bytes = request.pack(), header = request.getHeader(), trailer = request.getTrailer();
-            log.debug("Packed request '{}'", ISOUtil.byte2hex(bytes));
-            result.setSentBytes((long) bytes.length +
-                (header != null ? header.length : 0) + (trailer != null ? trailer.length : 0));
-        } catch (ISOException e) {
-            log.error("Packager error on request '{}'. Check config! {}", getName(), e.toString());
         }
 
         // Response validation...


### PR DESCRIPTION
Fix for #24.

This appears to be caused by whatever jPOS does with the message after handing it over to the QMUX (as can be demonstrated by stubbing the [`MUX.request`](https://github.com/tilln/jmeter-iso8583/blob/1a47d8d6adbf34dad983764a0dab919636c9958b/src/main/java/nz/co/breakpoint/jmeter/iso8583/ISO8583Sampler.java#L220) call).

This workaround simply gets all the request details for the SampleResult **before** sending the request and thereby avoids the issue.